### PR TITLE
Page action fix

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -16,14 +16,16 @@ chrome.tabs.onUpdated.addListener(function(id, info, tab){
         return;
     }
 
+    if (tab.url.toLowerCase().indexOf("facebook.com") !== -1){
+            // show the page action if on facebook.com
+        chrome.pageAction.show(tab.id);
+    }
+
     if (localStorage["be_a_buzzkill"] == "true"){
 
         if (tab.url.toLowerCase().indexOf("facebook.com/buzzfeed") !== -1){
             chrome.tabs.update(tab.id, {url: "http://www.facebook.com/?no-buzzfeed-for-you!"});
         }
-
-        // show the page action
-        chrome.pageAction.show(tab.id);
 
         // inject the content script onto the page
         console.log("getting ready to be a buzz kill...");
@@ -31,11 +33,16 @@ chrome.tabs.onUpdated.addListener(function(id, info, tab){
     }
 
 });
+//NAlexiou Comments:
+//Since pageAction includes a popup html, this will not trigger based on Chrome documentation.
+//Also, this code essential says this: when the page action (icon) is clicked, display the page action (icon).
+//When Buzzfeed was set to false, the page action would disappear and it would not show up until 
+//the extension was reloaded. Code to display page action was modified in the onUpdate code block.
 
-// show the popup when the user clicks on the page action.
-chrome.pageAction.onClicked.addListener(function(tab) {
-    chrome.pageAction.show(tab.id);
-});
+// // show the popup when the user clicks on the page action.
+// chrome.pageAction.onClicked.addListener(function(tab) {
+//     chrome.pageAction.show(tab.id);
+// });
 
 
 // update the icon when the user's settings change

--- a/bootstrap.js
+++ b/bootstrap.js
@@ -33,16 +33,7 @@ chrome.tabs.onUpdated.addListener(function(id, info, tab){
     }
 
 });
-//NAlexiou Comments:
-//Since pageAction includes a popup html, this will not trigger based on Chrome documentation.
-//Also, this code essential says this: when the page action (icon) is clicked, display the page action (icon).
-//When Buzzfeed was set to false, the page action would disappear and it would not show up until 
-//the extension was reloaded. Code to display page action was modified in the onUpdate code block.
 
-// // show the popup when the user clicks on the page action.
-// chrome.pageAction.onClicked.addListener(function(tab) {
-//     chrome.pageAction.show(tab.id);
-// });
 
 
 // update the icon when the user's settings change


### PR DESCRIPTION
Hi Hartley,

Thanks for the awesome blog post. It really clarified many unknowns that I had with Chrome extensions. While I was playing around with the code, I realized that it was not behaving as I was expecting. 

So, I removed the following code:

// show the popup when the user clicks on the page action.
chrome.pageAction.onClicked.addListener(function(tab) {
    chrome.pageAction.show(tab.id);
});

and also modified the onUpdate code block.

Here is my reasoning:

Since pageAction includes a popup html, this will not trigger based on Chrome documentation.
https://developer.chrome.com/extensions/pageAction#event-onClicked 
Also, this code essential says this: when the page action (icon) is clicked, display the page action (icon). 
So, if the page action is not displayed, you can't click on it to display it. When Buzzfeed was set to false (checkbox in popup unchecked) and page was refreshed, the page action would disappear and it would not show up until the extension was reloaded. The code to display page action was added/modified in the onUpdate code block.

If you merge these changes to your branch, I would also change the blog post to reflect this since I was confused with this part when I was reading it.
